### PR TITLE
fix: person and company predicates

### DIFF
--- a/dedupe/variables/name.py
+++ b/dedupe/variables/name.py
@@ -97,18 +97,19 @@ class WesternNameType(ParseratorType) :
                                ('Household', self.compareHouseholds,
                                 FIRST_NAMES_A + LAST_NAMES_A,
                                 FIRST_NAMES_B + LAST_NAMES_B))
+            block_parts = ('Surname',)
         elif self.name_type == 'company':
             self.components = (('Corporation', self.compareFields, CORPORATION),)
+            block_parts = ('CorporationName',)
         elif self.name_type is None:
             self.components = (('Person' , self.compareFields, PERSON),
                                ('Household', self.compareHouseholds,
                                 FIRST_NAMES_A + LAST_NAMES_A,
                                 FIRST_NAMES_B + LAST_NAMES_B),
                                ('Corporation', self.compareFields, CORPORATION))
+            block_parts = ('Surname', 'CorporationName')
         else:
             raise ValueError("valid values of name type are 'person' and 'company'")
-
-        block_parts = ('Surname', 'CorporationName')
 
         super(WesternNameType, self).__init__(definition, probablepeople.tag, block_parts)
 

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -40,6 +40,10 @@ class TestName(unittest.TestCase):
               0,   1,   0,   0,   0,   1,   0,   0,
               0,   0,   0,   0,   0 ])
 
+        predicates_parts = (getattr(p, "part", None) for p in name.predicates)
+        assert not any(p == 'CorporationName' for p in predicates_parts)
+
+
     def test_company_type(self):
         name = WesternNameType({'field' : 'foo', 'name type' : 'company'})
         print(name.comparator('James and Rita Allen',
@@ -52,7 +56,9 @@ class TestName(unittest.TestCase):
               0,  0,  0,  0,  0,  0,  0,  1,  0,
               0,  0,  0,  0,  0,  0,  0,  0,  0,
               0,  0])
-                                           
+        predicates_parts = (getattr(p, "part", None) for p in name.predicates)
+        assert not any(p == 'Surname' for p in predicates_parts)
+
                                            
         
 def prettyPrint(variable, comparison) :


### PR DESCRIPTION
# Bug description

While training a `Gazetteer` on data with a `person` field and no other name field, I noticed that predicates like `PartialIndexLevenshteinSearchPredicate: (3, best_looking_name, CorporationName)` were wrongly  generated as well as the expected `PartialIndexLevenshteinSearchPredicate: (3, best_looking_name, Surname)`.

This happens because `block_parts` were not properly set when initialization of the `WesternNameType` depending on the `WesternNameType.name_type`

# Changes

## Fixed
- when initializing `WesternNameType`, appropriately set the `block_parts` depending on the `WesternNameType.name_type` before calling the parent `ParseratorType.__init__`
